### PR TITLE
Fix node use cjs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
       "import": "./dist/index.js"
     }
   },
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -28,7 +28,7 @@
       "import": "./dist/index.js"
     }
   },
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
虽然 exports 中的"."配置会具有较高优先级，此提交依然修复了main/module 中的错误路径（我在 nuxt 项目中使用插件时发现该错误，疑似 exports  的优先级配置并未生效）。