### PR TITLE
Fix Rspack plugin ESM package entrypoints

### DIFF
--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -25,13 +25,16 @@
   "type": "module",
   "sideEffects": false,
   "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "require": "./dist/index.d.cts",
+        "import": "./dist/index.d.mts"
+      },
       "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Update `@plugin-web-update-notification/rspack` package metadata to point ESM and declaration consumers at the files emitted by `tsdown`.
- Keep the CommonJS entrypoint on `dist/index.cjs`.
- Use split declaration targets for `require` and `import`, matching the emitted `index.d.cts` and `index.d.mts` files.

## Why

The published `2.1.0` package ships `dist/index.mjs` and `dist/index.d.mts`, but `package.json` currently points ESM consumers at `dist/index.js` and TypeScript consumers at `dist/index.d.ts`. A clean ESM import therefore resolves to a file that is not present in the package and fails with `ERR_MODULE_NOT_FOUND`.

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter=@plugin-web-update-notification/rspack build`
- verified all `main` / `module` / `types` / `exports` targets exist after build
- `corepack pnpm pack --pack-destination /tmp/plugin-web-update-rspack-fixed`
- installed the packed tarball in a clean temp project
- verified `import('@plugin-web-update-notification/rspack')` succeeds
- verified `require('@plugin-web-update-notification/rspack')` succeeds
- `npx tsc index.ts --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项**
  * 优化了包的导出配置，改进了对 CommonJS 和 ES Module 两种模块格式的支持
  * 调整了类型声明文件的映射，为不同模块格式提供对应的类型定义文件

<!-- end of auto-generated comment: release notes by coderabbit.ai -->